### PR TITLE
Rails 5.2 support

### DIFF
--- a/lib/active_model/associations.rb
+++ b/lib/active_model/associations.rb
@@ -21,19 +21,14 @@ module ActiveModel
 
     module ClassMethods
       # define association like ActiveRecord
-      def belongs_to(name, scope = nil, options = {})
+      def belongs_to(name, scope = nil, **options)
         reflection = ActiveRecord::Associations::Builder::BelongsTo.build(self, name, scope, options)
         ActiveRecord::Reflection.add_reflection self, name, reflection
       end
 
       # define association like ActiveRecord
-      def has_many(name, scope = nil, options = {}, &extension)
+      def has_many(name, scope = nil, **options, &extension)
         options.reverse_merge!(active_model: true, target_ids: "#{name.to_s.singularize}_ids")
-        if scope.is_a?(Hash)
-          options.merge!(scope)
-          scope = nil
-        end
-
         reflection = ActiveRecord::Associations::Builder::HasManyForActiveModel.build(self, name, scope, options, &extension)
         ActiveRecord::Reflection.add_reflection self, name, reflection
 

--- a/lib/active_model/associations/association_scope_extension.rb
+++ b/lib/active_model/associations/association_scope_extension.rb
@@ -1,6 +1,15 @@
 module ActiveModel::Associations
   module AssociationScopeExtension
-    if ActiveRecord.version >= Gem::Version.new("5.0.0.beta")
+    if ActiveRecord.version >= Gem::Version.new("5.1.0")
+      def add_constraints(scope, owner, refl, chain_head, chain_tail)
+        if refl.options[:active_model]
+          target_ids = refl.options[:target_ids]
+          return scope.where(id: owner[target_ids])
+        end
+
+        super
+      end
+    elsif ActiveRecord.version >= Gem::Version.new("5.0.0")
       def add_constraints(scope, owner, association_klass, refl, chain_head, chain_tail)
         if refl.options[:active_model]
           target_ids = refl.options[:target_ids]

--- a/lib/active_model/associations/association_scope_extension.rb
+++ b/lib/active_model/associations/association_scope_extension.rb
@@ -1,6 +1,17 @@
 module ActiveModel::Associations
   module AssociationScopeExtension
-    if ActiveRecord.version >= Gem::Version.new("5.1.0")
+    if ActiveRecord.version >= Gem::Version.new("5.2.0")
+      def add_constraints(scope, owner, chain)
+        chain_head = chain.first
+        refl = chain_head.instance_variable_get(:@reflection)
+        if refl.options[:active_model]
+          target_ids = refl.options[:target_ids]
+          return scope.where(id: owner[target_ids])
+        end
+
+        super
+      end
+    elsif ActiveRecord.version >= Gem::Version.new("5.1.0")
       def add_constraints(scope, owner, refl, chain_head, chain_tail)
         if refl.options[:active_model]
           target_ids = refl.options[:target_ids]


### PR DESCRIPTION
Actually we no longer depends on activemodel-associations, but in the past this branch helped us when upgrading Rails to 5.2 so I hope it will also help for anybody.